### PR TITLE
try to fix env value has =

### DIFF
--- a/j2cli3/context.py
+++ b/j2cli3/context.py
@@ -122,7 +122,7 @@ def _parse_env(data_string):
             (
                 list(map(
                     strip,
-                    line.split('=')
+                    line.split('=',1)
                 ))
                 for line in data_string.split("\n")
             )


### PR DESCRIPTION
be default split has maxsplit =-1, then there is no limit on the number of splits (all possible splits are made).
By setting maxsplit  = 1, we can use = in env value